### PR TITLE
Apply this.delegateEvents() on initialize.

### DIFF
--- a/backbone-elements.js
+++ b/backbone-elements.js
@@ -53,6 +53,7 @@
           this.events = this.mapEvents(this.events);
           this.refreshElements();
           initialize.apply(this, arguments);
+          this.delegateEvents();
         },
 
         /**


### PR DESCRIPTION
For some reason my events are not delegated upon initialisation. I have to manually run this.delegateEvents() after calling on super(). This small patch fixes that for me.
